### PR TITLE
fix: frontend rebuild skipped when type unchanged but dist/ missing

### DIFF
--- a/saviour-config
+++ b/saviour-config
@@ -1420,7 +1420,13 @@ run_configuration() {
 
     set_device_hostname
 
-    if $type_changed && [ "$DEVICE_ROLE" = "controller" ]; then
+    # Also rebuild if dist/ is simply missing -- e.g. after a fresh git clone
+    # or reset of this repo directory, which wipes the gitignored build output
+    # without touching /etc/saviour/.provisioned (that marker lives outside
+    # the repo and survives re-clones, so type_changed alone would wrongly
+    # read as "nothing to do").
+    if [ "$DEVICE_ROLE" = "controller" ] && \
+       { $type_changed || [ ! -d "${DIR}/src/controller/frontend/dist" ]; }; then
         build_frontend
     fi
 


### PR DESCRIPTION
build_frontend() was gated solely on type_changed vs /etc/saviour/.provisioned, a marker that lives outside the repo and survives a fresh git clone or reset. After re-cloning this repo the gitignored node_modules/dist are gone, but if the declared role/type still matches the last-applied state, the build step was skipped entirely -- leaving the controller serving a stale or missing frontend with no error surfaced.

Now also rebuilds whenever src/controller/frontend/dist is absent.