### PR TITLE
fix: upgrade react-router to 8.3.0, resolving RSC CSRF advisory

### DIFF
--- a/src/controller/frontend/package-lock.json
+++ b/src/controller/frontend/package-lock.json
@@ -8,9 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1",
-        "react-router-dom": "^7.9.4",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router": "^8.3.0",
         "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
@@ -56,7 +56,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1451,7 +1450,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1493,7 +1491,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1602,7 +1599,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1699,18 +1695,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1858,7 +1847,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2533,7 +2521,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2591,26 +2578,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
-      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.5"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-refresh": {
@@ -2624,41 +2609,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz",
-      "integrity": "sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz",
-      "integrity": "sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/resolve-from": {
@@ -2731,12 +2699,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2902,7 +2864,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/src/controller/frontend/package.json
+++ b/src/controller/frontend/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.4",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.3.0",
     "socket.io-client": "^4.8.1"
   },
   "devDependencies": {

--- a/src/controller/frontend/src/acoustic_startle/App.jsx
+++ b/src/controller/frontend/src/acoustic_startle/App.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import "./App.css";
 
 

--- a/src/controller/frontend/src/apa/App.jsx
+++ b/src/controller/frontend/src/apa/App.jsx
@@ -1,6 +1,6 @@
 import '../basic/App.css';
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 
 import Sidebar from "../basic/components/Sidebar/Sidebar";
 import APADashboard from "./pages/APADashboard/APADashboard";

--- a/src/controller/frontend/src/apa/components/APAHeader/APAHeader.jsx
+++ b/src/controller/frontend/src/apa/components/APAHeader/APAHeader.jsx
@@ -1,7 +1,7 @@
 // React imports
 import React, { useEffect, useState } from "react";
 import socket from "../../../socket";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 // Style imports
 import './APAHeader.css';

--- a/src/controller/frontend/src/basic/App.jsx
+++ b/src/controller/frontend/src/basic/App.jsx
@@ -4,7 +4,7 @@ import React,  { useEffect, useRef, useState } from "react";
 
 // SAVIOUR Imports
 import Sidebar from "./components/Sidebar/Sidebar";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router";
 import Dashboard from "./pages/Dashboard/Dashboard";
 import Settings from "./pages/Settings/Settings";
 import Recording from "./pages/Recording/Recording";

--- a/src/controller/frontend/src/basic/components/Header/Header.jsx
+++ b/src/controller/frontend/src/basic/components/Header/Header.jsx
@@ -1,7 +1,7 @@
 // React imports
 import React, { useEffect, useState } from "react";
 import socket from "../../../socket";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 
 // Style imports
 import './Header.css';

--- a/src/controller/frontend/src/basic/components/HealthSummaryWidget/HealthSummaryWidget.jsx
+++ b/src/controller/frontend/src/basic/components/HealthSummaryWidget/HealthSummaryWidget.jsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { useEffect, useState } from "react";
 import useHealth from "/src/hooks/useHealth";
 import useModules from "/src/hooks/useModules";

--- a/src/controller/frontend/src/basic/components/RecordingStatusWidget/RecordingStatusWidget.jsx
+++ b/src/controller/frontend/src/basic/components/RecordingStatusWidget/RecordingStatusWidget.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import useSessions from "/src/hooks/useSessions";
 import useModules from "/src/hooks/useModules";
 import useHealth from "/src/hooks/useHealth";

--- a/src/controller/frontend/src/basic/components/Sidebar/Sidebar.jsx
+++ b/src/controller/frontend/src/basic/components/Sidebar/Sidebar.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { NavLink, useNavigate, useLocation } from "react-router-dom";
+import { NavLink, useNavigate, useLocation } from "react-router";
 import socket from "/src/socket";
 import { isLoggedIn, onAuthChange, logOut } from "/src/auth";
 

--- a/src/controller/frontend/src/habitat/App.jsx
+++ b/src/controller/frontend/src/habitat/App.jsx
@@ -1,6 +1,6 @@
 import './App.css';
 import React, { useEffect, useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 
 import Sidebar from '../basic/components/Sidebar/Sidebar';
 import Settings from "../basic/pages/Settings/Settings";

--- a/src/controller/frontend/src/habitat/components/HabitatLivestreamGrid/HabitatLivestreamGrid.jsx
+++ b/src/controller/frontend/src/habitat/components/HabitatLivestreamGrid/HabitatLivestreamGrid.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import "./HabitatLivestreamGrid.css";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 import HabitatLivestreamCard from "../HabitatLivestreamCard/HabitatLivestreamCard";
 
 const STREAM_REFRESH_MS = 60 * 1000;

--- a/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.jsx
+++ b/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import socket from "/src/socket";
 import "./HabitatRecordingControl.css";
 

--- a/src/controller/frontend/src/habitat/pages/Monitor/Monitor.jsx
+++ b/src/controller/frontend/src/habitat/pages/Monitor/Monitor.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import "./Monitor.css";
 
 import useModules from "/src/hooks/useModules";

--- a/src/controller/frontend/src/loom/App.jsx
+++ b/src/controller/frontend/src/loom/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation } from "react-router";
 import "./App.css";
 
 import Sidebar from "/src/basic/components/Sidebar/Sidebar";

--- a/src/controller/frontend/src/main.jsx
+++ b/src/controller/frontend/src/main.jsx
@@ -4,7 +4,7 @@ import './index.css';
 import ThemedApp from './ThemedApp';
 import AuthGate from './basic/components/AuthGate/AuthGate';
 import ChangePasswordModal from './basic/components/ChangePasswordModal/ChangePasswordModal';
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter } from "react-router";
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
react-router-dom never published a fix (still 7.18.2, pulling the vulnerable react-router 7.x range) - react-router-dom is deprecated as of v8, folded into the react-router package itself. Drop react-router-dom and import BrowserRouter/Routes/Route/Link/NavLink/ useNavigate/useLocation from react-router directly across all five frontend variants. Requires react/react-dom >=19.2.7 (bumped from 19.1.1), react-router's new peer dependency floor.

The advisory only affects unstable RSC APIs, which this plain BrowserRouter SPA doesn't use, so there was no exploitable path here - this closes the Dependabot alert rather than fixing a live exposure.