### PR TITLE
fix(notify): don't suppress a never-seen alert key on a small monoton…

### DIFF
--- a/src/controller/notify.py
+++ b/src/controller/notify.py
@@ -62,8 +62,8 @@ class Notifier:
         cooldown = self.config.get("teams.alert_cooldown_secs", 600)
         now = time.monotonic()
         with self._lock:
-            last = self._last_sent.get(key, 0)
-            if now - last < cooldown:
+            last = self._last_sent.get(key)
+            if last is not None and now - last < cooldown:
                 return
             self._last_sent[key] = now
 

--- a/src/controller/tests/test_notify.py
+++ b/src/controller/tests/test_notify.py
@@ -74,6 +74,20 @@ class TestSendAlert:
 
         assert mock_thread.call_count == 2
 
+    def test_first_alert_is_not_suppressed_when_monotonic_clock_is_small(self):
+        # time.monotonic()'s reference point is undefined -- on a freshly
+        # booted CI runner it can be well under the cooldown window. A
+        # never-seen key must not be suppressed just because `now` is small.
+        notifier = _make_notifier(**{
+            "teams.webhook_url": "https://example.invalid/webhook",
+            "teams.alert_cooldown_secs": 600,
+        })
+        with patch("src.controller.notify.threading.Thread") as mock_thread, \
+             patch("src.controller.notify.time.monotonic", return_value=5.0):
+            notifier.send_alert("key1", "title", "message")
+
+        mock_thread.assert_called_once()
+
     def test_zero_cooldown_allows_immediate_repeats(self):
         notifier = _make_notifier(**{
             "teams.webhook_url": "https://example.invalid/webhook",


### PR DESCRIPTION
…ic clock

send_alert() defaulted a missing dedup key to 0, then compared `now - 0 < cooldown`. time.monotonic()'s reference point is undefined -- on a freshly booted CI runner `now` can be smaller than the default 600s cooldown, so the very first alert for a brand-new key was wrongly treated as a recent duplicate and silently dropped (no Thread ever dispatched). This is exactly what broke test_notify.py in CI while passing locally on a long-uptime dev machine. Fixed by using None as the "never sent" sentinel with an explicit is-not-None guard, and added a regression test that mocks time.monotonic to a small value.