### PR TITLE
fix: size dashboard livestream cards to actual stream aspect ratio

### DIFF
--- a/src/controller/frontend/src/basic/components/MJPEGStreamCard/MJPEGStreamCard.jsx
+++ b/src/controller/frontend/src/basic/components/MJPEGStreamCard/MJPEGStreamCard.jsx
@@ -18,9 +18,15 @@ const MIN_RECONNECT_MS = 3000;
  * Handles stall detection and reconnection for any module that serves
  * an MJPEG stream at http://{ip}:{port}/video_feed.
  */
-function MJPEGStreamCard({ ip, port = 8080, label, isRecording = false }) {
+function MJPEGStreamCard({ ip, port = 8080, label, isRecording = false, onAspectRatio }) {
   const [fullscreen, setFullscreen] = useState(false);
   const [streamKey, setStreamKey] = useState(Date.now());
+  // Actual aspect ratio of the stream, discovered from the first loaded
+  // frame — streams aren't all 16:9 (e.g. square camera crops), and a
+  // hardcoded ratio leaves either the card or the image letterboxed with
+  // dead space. Re-detected on every reconnect in case a config change
+  // (e.g. livestream_quality, resolution) altered it.
+  const [aspectRatio, setAspectRatio] = useState(null);
   const stallTimer = useRef(null);
   const reconnectTimer = useRef(null);
   const lastBumpAt       = useRef(0);
@@ -54,6 +60,7 @@ function MJPEGStreamCard({ ip, port = 8080, label, isRecording = false }) {
   };
 
   useEffect(() => {
+    setAspectRatio(null);
     stallTimer.current = setTimeout(bump, STALL_TIMEOUT_MS);
     return () => {
       clearTimeout(stallTimer.current);
@@ -87,7 +94,15 @@ function MJPEGStreamCard({ ip, port = 8080, label, isRecording = false }) {
   // timer forever every STALL_TIMEOUT_MS regardless of stream health,
   // forcing a full reconnect (and killing the live video) on a healthy
   // stream. Recovery from a stream that actually dies is handled by onError.
-  const handleLoad = () => clearTimeout(stallTimer.current);
+  const handleLoad = (e) => {
+    clearTimeout(stallTimer.current);
+    const { naturalWidth, naturalHeight } = e.target;
+    if (naturalWidth && naturalHeight) {
+      const ratio = naturalWidth / naturalHeight;
+      setAspectRatio(ratio);
+      onAspectRatio?.(ratio);
+    }
+  };
 
   const handleError = () => {
     clearTimeout(stallTimer.current);
@@ -103,7 +118,10 @@ function MJPEGStreamCard({ ip, port = 8080, label, isRecording = false }) {
             <span className="mjpeg-stream-label">{label}</span>
           </div>
         )}
-        <div className="mjpeg-stream-video">
+        <div
+          className="mjpeg-stream-video"
+          style={aspectRatio ? { "--stream-ratio": aspectRatio } : undefined}
+        >
           <img
             key={streamKey}
             ref={imgRef}

--- a/src/controller/frontend/src/basic/pages/Dashboard/Dashboard.css
+++ b/src/controller/frontend/src/basic/pages/Dashboard/Dashboard.css
@@ -22,7 +22,12 @@
   flex: 2;
   display: grid;
   /* column count set via inline style on the element */
-  grid-auto-rows: 1fr;
+  grid-auto-rows: auto;
+  /* grid-auto-rows: auto still stretches rows to fill a definite-height
+     container by default — this container gets one from flex:2 above, so
+     without this, cards would bloat back out to fill the column exactly
+     like the old 1fr did. */
+  align-content: start;
   gap: 12px;
   min-width: 0;
   min-height: 0;
@@ -32,6 +37,30 @@
 .dashboard-cameras .mjpeg-stream-card {
   min-width: 0;
   min-height: 0;
+  /* Grid items stretch to fill their column by default — shrink the card
+     itself to wrap its (aspect-ratio-constrained) content and center it,
+     otherwise the card's background/border still spans the full column
+     even once the video inside it stops doing so, showing as empty card
+     space rather than neutral page background either side of it. */
+  width: fit-content;
+  max-width: 100%;
+  justify-self: center;
+}
+
+/* Size the video area to a cell size that (a) matches the stream's real
+   aspect ratio and (b) is guaranteed to fit rows x cols within the grid's
+   measured box (--cell-w/--cell-h, computed in Dashboard.jsx's
+   fitCellSize()) — a square stream in a wide column would otherwise sit in
+   a much taller card than it needs (blank card space), or the grid would
+   grow taller than the viewport and force the whole dashboard to scroll.
+   Before the grid's size / the stream's ratio are known, fall back to
+   100%-wide with an assumed 16:9 so nothing flashes at zero size. */
+.dashboard-cameras .mjpeg-stream-video {
+  flex: none;
+  width: var(--cell-w, 100%);
+  height: var(--cell-h, auto);
+  aspect-ratio: var(--stream-ratio, 16 / 9);
+  margin: 0 auto;
 }
 
 /* ── Group filter bar ────────────────────────────────────────────────────── */
@@ -128,12 +157,14 @@
   display: grid;
   gap: 8px;
   flex-shrink: 0;
+  align-content: start;
 }
 
-/* Lock the video area to 16:9 so cards don't bloat with empty space */
+/* Size to the stream's real aspect ratio (see .dashboard-cameras above) so
+   cards don't bloat with empty space; 16:9 is only a pre-first-frame guess. */
 .dashboard-compact-streams .mjpeg-stream-video {
   flex: none;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: var(--stream-ratio, 16 / 9);
 }
 
 .dashboard-compact-panel {

--- a/src/controller/frontend/src/basic/pages/Dashboard/Dashboard.jsx
+++ b/src/controller/frontend/src/basic/pages/Dashboard/Dashboard.jsx
@@ -29,10 +29,79 @@ function useIsCompact() {
   return isCompact;
 }
 
+// Tracks an element's content-box size. Uses a callback ref (not
+// useRef+one-shot useEffect) so it reattaches correctly when the element
+// itself mounts/unmounts — e.g. the wide/compact dashboard layouts swap
+// which grid div exists as the window crosses COMPACT_BREAKPOINT.
+function useElementSize() {
+  const [node, setNode] = useState(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    if (!node) return;
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      setSize({ width, height });
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+  return [setNode, size];
+}
+
+const GRID_GAP_PX = 12;
+// Fixed vertical chrome per card outside the video box itself (the ~8px
+// top/bottom padding plus the uppercase label header) — subtracted from the
+// per-row height budget so the fitted grid doesn't overshoot by a few
+// pixels per row and reintroduce a scrollbar.
+const CARD_CHROME_PX = 40;
+
+// Largest (width, height) matching `ratio` that still fits `cols` columns x
+// `rows` rows inside a `containerW` x `containerH` box — so the camera grid
+// always fits the available space instead of overflowing and forcing the
+// dashboard to scroll.
+function fitCellSize(containerW, containerH, cols, rows, ratio) {
+  if (!containerW || !containerH || cols < 1 || rows < 1) return null;
+  const availW = containerW - GRID_GAP_PX * (cols - 1);
+  const availH = containerH - GRID_GAP_PX * (rows - 1) - CARD_CHROME_PX * rows;
+  if (availW <= 0 || availH <= 0) return null;
+  let width = availW / cols;
+  let height = width / ratio;
+  if (height * rows > availH) {
+    height = availH / rows;
+    width = height * ratio;
+  }
+  return { width, height };
+}
+
+// Picks the column count (1..n) that yields the largest per-card area for
+// `n` same-ratio cards in a containerW x containerH box. A fixed column
+// count picked from `n` alone (the old heuristic) can land on a layout
+// that's row-bound — e.g. 2 cameras stacked in 1 column, 2 rows — leaving
+// each card's width unused once fitCellSize shrinks it to fit the row
+// budget. Trying every column count and keeping the biggest result finds
+// the arrangement that actually uses the most of the available box.
+function bestCameraLayout(containerW, containerH, n, ratio) {
+  if (!containerW || !containerH || n === 0) return null;
+  let best = null;
+  for (let cols = 1; cols <= n; cols++) {
+    const rows = Math.ceil(n / cols);
+    const cellSize = fitCellSize(containerW, containerH, cols, rows, ratio);
+    if (!cellSize) continue;
+    const area = cellSize.width * cellSize.height;
+    if (!best || area > best.area) best = { cols, cellSize, area };
+  }
+  return best;
+}
+
 function Dashboard() {
   const { moduleList } = useModules();
   const [selectedGroup, setSelectedGroup] = useState("all");
   const isCompact = useIsCompact();
+  const [camerasGridRef, camerasGridSize] = useElementSize();
+  // Real aspect ratio of the camera streams, discovered from the first
+  // loaded frame — used to fit the grid (see fitCellSize above). Assumes a
+  // uniform ratio across camera modules, which holds for a real rig.
+  const [streamRatio, setStreamRatio] = useState(16 / 9);
 
   const groups = useMemo(() => {
     const names = [...new Set(moduleList.map(m => m.group).filter(Boolean))].sort();
@@ -47,8 +116,15 @@ function Dashboard() {
   const micModules    = visibleModules.filter(m => m.type === "microphone");
   const ttlModules    = visibleModules.filter(m => m.type === "ttl");
 
-  // Optimal column count for wide camera grid
-  const cameraCols = (() => { const n = cameraModules.length; return n <= 2 ? 1 : n <= 4 ? 2 : n <= 9 ? 3 : 4; })();
+  // Column count used before the grid's box has been measured yet (first
+  // render) — a reasonable guess so nothing flashes unstyled.
+  const cameraColsFallback = (() => { const n = cameraModules.length; return n <= 2 ? 1 : n <= 4 ? 2 : n <= 9 ? 3 : 4; })();
+  const cameraLayout = useMemo(
+    () => bestCameraLayout(camerasGridSize.width, camerasGridSize.height, cameraModules.length, streamRatio),
+    [camerasGridSize.width, camerasGridSize.height, cameraModules.length, streamRatio]
+  );
+  const cameraCols = cameraLayout?.cols ?? cameraColsFallback;
+  const cameraCellSize = cameraLayout?.cellSize ?? null;
 
   // Flat ordered list of all streams — used by the compact grid
   const allStreams = useMemo(() => [
@@ -115,7 +191,17 @@ function Dashboard() {
       ) : (
         /* ── Wide: cameras left, status panel right ── */
         <div className="dashboard-main">
-          <div className="dashboard-cameras" style={{ gridTemplateColumns: `repeat(${cameraCols}, 1fr)` }}>
+          <div
+            className="dashboard-cameras"
+            ref={camerasGridRef}
+            style={{
+              gridTemplateColumns: `repeat(${cameraCols}, 1fr)`,
+              ...(cameraCellSize && {
+                "--cell-w": `${cameraCellSize.width}px`,
+                "--cell-h": `${cameraCellSize.height}px`,
+              }),
+            }}
+          >
             {cameraModules.length === 0 ? (
               <div className="dashboard-no-cameras">No camera modules connected</div>
             ) : (
@@ -126,6 +212,7 @@ function Dashboard() {
                   port={STREAM_PORTS.camera}
                   label={m.name}
                   isRecording={m.status === "RECORDING"}
+                  onAspectRatio={setStreamRatio}
                 />
               ))
             )}


### PR DESCRIPTION
Camera cards previously stretched to fill their grid row/column regardless of the served stream's real shape, leaving large blank card areas for non-16:9 streams (e.g. a square crop). MJPEGStreamCard now detects the real aspect ratio from the loaded frame, and the dashboard grid picks the column/row arrangement and cell size that best fills the measured container without overflowing it (avoiding a forced scrollbar), then shrink-wraps and centers each card to its computed size so leftover space reads as page background rather than empty card interior.