### PR TITLE
fix(test): disable pytest cacheprovider to stop orphaned cache dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# pytest cache (also disabled via -p no:cacheprovider; this is a safety net)
+.pytest_cache/
+pytest-cache-files-*/
+
 # Distribution / packaging
 dist/
 build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["src/controller/tests", "src/modules/tests", "src/tests"]
 python_files = ["test_*.py"]
-addopts = "-v"
+addopts = "-v -p no:cacheprovider"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
On this repo's UNC-path network share, pytest's cache plugin can't atomically write .pytest_cache/v/cache/* (Access is denied), so every run silently leaves behind an unremovable pytest-cache-files-XXXXXXXX temp dir instead of cleaning up. 140 of these had accumulated. Deleted them (their ACLs excluded the owning user, needed an icacls grant before they could be removed) and disabled the cache plugin via -p no:cacheprovider in addopts, since nothing here uses --lf/--ff or the cache fixture. Also added a .gitignore entry as a safety net.