### PR TITLE
fix(frontend): bump socket.io-parser to 4.2.7, fixes GHSA-2m8v-j782-fhvr

### DIFF
--- a/src/controller/frontend/package-lock.json
+++ b/src/controller/frontend/package-lock.json
@@ -2739,9 +2739,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
Transitive dep of socket.io-client 4.8.3, pinned to 4.2.6 in the lockfile. Versions <4.2.7 let a crafted Socket.IO packet make the server buffer an unbounded number of binary attachments, exhausting memory (CVE-2026-69185, Dependabot alert #44, CVSS 7.5 high). 4.2.7 satisfies socket.io-client's existing "~4.2.4" range, so no package.json change is needed.