### PR TITLE
fix: forward loom ROI editor's save status to the frontend

### DIFF
--- a/src/controller/web.py
+++ b/src/controller/web.py
@@ -2110,6 +2110,16 @@ class Web(ABC):
                         'error': error,
                     })
 
+                # loom_camera_module.py's set_loom_roi() sends this directly via
+                # communication.send_status() on a successful save. Previously
+                # unmatched here -- fell to case _ -> handle_special_module_status(),
+                # which loom_controller.py doesn't override for this type (logs
+                # "No logic for loom_roi_updated" and drops), so
+                # LoomRoiLineEditorModal.jsx's "Saving..." status never resolved to
+                # "Saved" even on success.
+                case "loom_roi_updated":
+                    self.socketio.emit('module_status', {**status, 'module_id': module_id})
+
                 case "heartbeat":
                     version = status.get("version")
                     if version:
@@ -2140,6 +2150,20 @@ class Web(ABC):
                             })
                     elif command == "shutdown":
                         self.socketio.emit("module_shutdown_ack", {"module_id": module_id})
+                    elif command == "set_loom_roi" and status.get("status") == "error":
+                        # set_loom_roi's validation failures (bad polygon/line, or a
+                        # write error) come back as the command's own return value,
+                        # not a communication.send_status() call, so they surface
+                        # here as a cmd_ack rather than through the
+                        # loom_roi_updated case above. Previously fell to the
+                        # "no web-layer action" debug log below and was silently
+                        # dropped -- translated into the shape
+                        # LoomRoiLineEditorModal.jsx already listens for.
+                        self.socketio.emit('module_status', {
+                            'type': 'loom_roi_update_failed',
+                            'module_id': module_id,
+                            'error': status.get('error', 'unknown error'),
+                        })
                     else:
                         self.logger.debug(f"cmd_ack for '{command}' from {module_id} — no web-layer action")
 


### PR DESCRIPTION
Found while fixing the identical bug for the newly-added camera crop editor's status routing. loom_camera_module.py's set_loom_roi() sends a "loom_roi_updated" status directly via
communication.send_status() on success -- but web.py's handle_module_status() had no case for it, so it fell to case _ -> handle_special_module_status(), and loom_controller.py doesn't handle this type there either (logs "No logic for loom_roi_updated" and drops it). LoomRoiLineEditorModal.jsx's "Saving..." status therefore never resolved to "Saved" even when the save succeeded.

Worse on the failure path: set_loom_roi()'s validation errors (bad polygon/line, or a disk write failure) are returned as the command's own return value rather than sent via send_status(), so they surface as a "cmd_ack" with status="error" -- a shape the cmd_ack case's elif chain didn't recognise either, so it fell to the final "no web-layer action" debug log and was silently dropped too. Added a branch that translates this into the "loom_roi_update_failed" shape LoomRoiLineEditorModal.jsx already listens for (that type was never actually sent by any backend code before this -- dead code on the frontend side).

No frontend changes needed; both fixes are purely in web.py's central status dispatcher, following the same pattern already used for recording_started/stopped and (on the still-open feat/camera-crop-zoom branch) camera_crop_updated.