### PR TITLE
fix: loom_camera ROI/crossing-line survives code updates

### DIFF
--- a/src/modules/tests/test_loom_camera_module.py
+++ b/src/modules/tests/test_loom_camera_module.py
@@ -7,18 +7,22 @@ JSON + geometry parsing, exercised with real temp JSON files). The
 crossing-line debounce state machine (LoomCrossingState /
 loom_update_crossing_state) already has dedicated coverage in
 test_loom_crossing.py. LoomCameraModule itself (the CameraBase subclass)
-is out of scope here -- see test_camera_base.py for the __new__-based
-construction pattern that would apply to it too.
+is mostly out of scope here -- see test_camera_base.py for the
+__new__-based construction pattern that would apply to it too -- except
+for _resolve_roi_json_path's legacy-migration logic below, which is pure
+path/filesystem logic worth covering directly via that same pattern.
 """
 
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
 from src.modules.variants.loom_camera.loom_camera_module import (
     LoomBlobDiffTracker,
+    LoomCameraModule,
     loom_load_roi_and_line,
 )
 
@@ -216,3 +220,85 @@ class TestLoomLoadRoiAndLine:
             assert mask.all()
             assert poly is None
             assert line is None
+
+
+# ---------------------------------------------------------------------------
+# LoomCameraModule._resolve_roi_json_path -- legacy in-tree migration
+# ---------------------------------------------------------------------------
+
+def _make_module(roi_json_path):
+    mod = LoomCameraModule.__new__(LoomCameraModule)
+    mod.logger = MagicMock()
+    mod.config = MagicMock()
+    mod.config.get.return_value = {"roi_json_path": roi_json_path}
+    return mod
+
+
+class TestResolveRoiJsonPath:
+    def test_returns_none_when_unset(self):
+        mod = _make_module(None)
+        assert mod._resolve_roi_json_path() is None
+
+    def test_migrates_from_legacy_path_when_target_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            legacy = Path(tmpdir) / "legacy" / "roi.json"
+            legacy.parent.mkdir()
+            legacy.write_text(json.dumps({"created": "legacy"}))
+            target = Path(tmpdir) / "new" / "roi.json"
+
+            mod = _make_module(str(target))
+            with patch(
+                "src.modules.variants.loom_camera.loom_camera_module._LEGACY_ROI_JSON_PATH",
+                legacy,
+            ):
+                resolved = mod._resolve_roi_json_path()
+
+            assert resolved == target
+            assert json.loads(target.read_text()) == {"created": "legacy"}
+
+    def test_does_not_overwrite_an_existing_target(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            legacy = Path(tmpdir) / "legacy" / "roi.json"
+            legacy.parent.mkdir()
+            legacy.write_text(json.dumps({"created": "legacy"}))
+            target = Path(tmpdir) / "new" / "roi.json"
+            target.parent.mkdir()
+            target.write_text(json.dumps({"created": "already-calibrated"}))
+
+            mod = _make_module(str(target))
+            with patch(
+                "src.modules.variants.loom_camera.loom_camera_module._LEGACY_ROI_JSON_PATH",
+                legacy,
+            ):
+                mod._resolve_roi_json_path()
+
+            assert json.loads(target.read_text()) == {"created": "already-calibrated"}
+
+    def test_no_migration_when_legacy_file_absent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            legacy = Path(tmpdir) / "legacy" / "roi.json"  # never created
+            target = Path(tmpdir) / "new" / "roi.json"
+
+            mod = _make_module(str(target))
+            with patch(
+                "src.modules.variants.loom_camera.loom_camera_module._LEGACY_ROI_JSON_PATH",
+                legacy,
+            ):
+                resolved = mod._resolve_roi_json_path()
+
+            assert resolved == target
+            assert not target.exists()
+
+    def test_no_self_migration_when_configured_path_is_the_legacy_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            legacy = Path(tmpdir) / "roi.json"
+            legacy.write_text(json.dumps({"created": "legacy"}))
+
+            mod = _make_module(str(legacy))
+            with patch(
+                "src.modules.variants.loom_camera.loom_camera_module._LEGACY_ROI_JSON_PATH",
+                legacy,
+            ):
+                resolved = mod._resolve_roi_json_path()
+
+            assert resolved == legacy

--- a/src/modules/variants/loom_camera/loom_camera_config.json
+++ b/src/modules/variants/loom_camera/loom_camera_config.json
@@ -27,7 +27,7 @@
   },
   "loom_tracking": {
     "enabled": true,
-    "roi_json_path": "/usr/local/src/saviour/src/modules/variants/loom_camera/loom_roi_and_line.json",
+    "roi_json_path": "/etc/saviour/module/loom_roi_and_line.json",
     "max_full_rate_fps": 60,
     "process_width": 256,
     "thr_hi": 10.0,

--- a/src/modules/variants/loom_camera/loom_camera_module.py
+++ b/src/modules/variants/loom_camera/loom_camera_module.py
@@ -14,6 +14,7 @@ Author: Paul Rignanese / Andrew SG
 import json
 import logging
 import os
+import shutil
 import sys
 import time
 from dataclasses import dataclass
@@ -32,6 +33,15 @@ from modules.variants.loom_camera.loom_stimulus import (
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from modules.camera_base import CameraBase
 from modules.module import command
+
+# Pre-2026-08-24 default roi_json_path pointed here -- inside the deployed
+# source tree, so update_saviour's rsync (module.py, excludes only env/ and
+# .git/) silently overwrote a live-calibrated ROI with whatever was last
+# committed to git. Kept only as a one-time migration source for devices
+# still using that default; see _resolve_roi_json_path.
+_LEGACY_ROI_JSON_PATH = Path(
+    "/usr/local/src/saviour/src/modules/variants/loom_camera/loom_roi_and_line.json"
+)
 
 
 @dataclass(frozen=True)
@@ -493,10 +503,27 @@ class LoomCameraModule(CameraBase):
             return None
 
         roi_path = Path(str(p)).expanduser()
-        if roi_path.is_absolute():
-            return roi_path
+        if not roi_path.is_absolute():
+            roi_path = (Path(__file__).resolve().parent / roi_path).resolve()
 
-        return (Path(__file__).resolve().parent / roi_path).resolve()
+        # One-time migration: a device still pointed at the legacy in-tree
+        # default (or freshly updated to a config that now points elsewhere)
+        # gets its existing calibration copied to the new location instead of
+        # silently falling back to a full-frame ROI.
+        if (roi_path != _LEGACY_ROI_JSON_PATH
+                and not roi_path.exists()
+                and _LEGACY_ROI_JSON_PATH.exists()):
+            try:
+                roi_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(_LEGACY_ROI_JSON_PATH, roi_path)
+                self.logger.info(
+                    f"Migrated ROI JSON from legacy in-tree path: "
+                    f"{_LEGACY_ROI_JSON_PATH} -> {roi_path}"
+                )
+            except Exception as e:
+                self.logger.warning(f"Could not migrate legacy ROI JSON: {e}")
+
+        return roi_path
 
     def _set_default_roi(self, *, proc_w: int, proc_h: int) -> None:
         """


### PR DESCRIPTION
roi_json_path defaulted to an absolute path inside the deployed source tree (src/modules/variants/loom_camera/loom_roi_and_line.json), and that file is git-tracked. update_saviour's rsync (module.py) excludes only env/ and .git/, so every code update silently overwrote an operator's live-calibrated ROI/crossing-line back to whatever was last committed.

Default roi_json_path now points at /etc/saviour/module/, the same directory active_config.json already uses specifically because it survives rsync updates. _resolve_roi_json_path() gains a one-time migration: if the new path doesn't exist yet but the legacy in-tree file does, it's copied over so an already-deployed device doesn't silently fall back to a full-frame ROI on first boot after this change.

Note: devices already deployed will still lose any calibration done since the last git commit of the legacy file, because update_saviour's rsync overwrites it with the committed version before this fix's migration logic ever runs on that device. Re-calibrate once after deploying this update; it's safe from then on.