### PR TITLE
fix: habitat recording widget target-matching, add session Copy button

### DIFF
--- a/src/controller/frontend/src/acoustic_startle/App.css
+++ b/src/controller/frontend/src/acoustic_startle/App.css
@@ -12,4 +12,10 @@
     .content {
       flex: 1;
       overflow-x: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .content > .recording-status-widget {
+      flex-shrink: 0;
     }

--- a/src/controller/frontend/src/acoustic_startle/App.jsx
+++ b/src/controller/frontend/src/acoustic_startle/App.jsx
@@ -11,6 +11,7 @@ import Guide from "/src/basic/pages/Guide/Guide";
 
 import Dashboard from "/src/acoustic_startle/pages/AcousticStartleDashboard/AcousticStartleDashboard";
 import ConnectionOverlay from "/src/basic/components/ConnectionOverlay/ConnectionOverlay";
+import RecordingStatusWidget from "/src/basic/components/RecordingStatusWidget/RecordingStatusWidget";
 
 document.title="Acoustic Startle";
 
@@ -29,6 +30,7 @@ function App() {
         <div className="app">
             <Sidebar navItems={pages} />
             <div className="content">
+            <RecordingStatusWidget />
             <Routes>
                 <Route path="/" element={<Dashboard />} />
                 <Route path="/settings" element={<Settings />} />

--- a/src/controller/frontend/src/apa/App.jsx
+++ b/src/controller/frontend/src/apa/App.jsx
@@ -10,6 +10,7 @@ import System from "../basic/pages/System/System";
 import Debug from "../basic/pages/Debug/Debug";
 import Guide from "../basic/pages/Guide/Guide";
 import ConnectionOverlay from "../basic/components/ConnectionOverlay/ConnectionOverlay";
+import RecordingStatusWidget from "../basic/components/RecordingStatusWidget/RecordingStatusWidget";
 
 document.title = "APA";
 
@@ -26,6 +27,7 @@ function App() {
     <div className="app">
       <Sidebar navItems={pages} />
       <div className="content">
+        <RecordingStatusWidget />
         <Routes>
           <Route path="/" element={<APADashboard />} />
           <Route path="/recording/*" element={<Recording />} />

--- a/src/controller/frontend/src/basic/pages/Recording/NewSessionForm/NewSessionForm.jsx
+++ b/src/controller/frontend/src/basic/pages/Recording/NewSessionForm/NewSessionForm.jsx
@@ -14,7 +14,7 @@ const ALL_DAYS = new Set([0, 1, 2, 3, 4, 5, 6]);
 const daysSerialize = (days) => JSON.stringify([...days]);
 const daysDeserialize = (str) => new Set(JSON.parse(str));
 
-function NewSessionForm({ modules, sessionList = {}, target, setTarget, onSessionCreated }) {
+function NewSessionForm({ modules, sessionList = {}, target, setTarget, onSessionCreated, prefill }) {
   const { experimentName, experimenter } = useExperimentTitle();
   const [now, setNow] = useState(() => new Date());
   useEffect(() => {
@@ -83,6 +83,33 @@ function NewSessionForm({ modules, sessionList = {}, target, setTarget, onSessio
     new Set(ALL_DAYS),
     { serialize: daysSerialize, deserialize: daysDeserialize }
   );
+
+  // One-shot prefill from "Copy Session" (target is applied by the caller
+  // via setTarget before opening the drawer, since it's already lifted up
+  // to RecordingLayout). `prefill` is a fresh object per Copy click, so
+  // this fires exactly once per click rather than on every render -- not a
+  // plain initializer because mode/duration/schedule are persisted state,
+  // already populated before the operator ever copies a session.
+  useEffect(() => {
+    if (!prefill) return;
+    setRecordingMode(prefill.mode);
+    if (prefill.mode === "timed") {
+      const total = prefill.durationMinutes ?? 0;
+      setDurationHours(String(Math.floor(total / 60)));
+      setDurationMinutes(String(total % 60));
+    } else if (prefill.mode === "scheduled") {
+      const [sh, sm] = (prefill.scheduledStart || "19:00").split(":");
+      const [eh, em] = (prefill.scheduledEnd || "23:00").split(":");
+      setStartHour(sh);
+      setStartMinute(sm);
+      setEndHour(eh);
+      setEndMinute(em);
+      setScheduledDays(new Set(prefill.scheduledDays?.length ? prefill.scheduledDays : ALL_DAYS));
+    }
+  }, [
+    prefill, setRecordingMode, setDurationHours, setDurationMinutes,
+    setStartHour, setStartMinute, setEndHour, setEndMinute, setScheduledDays,
+  ]);
 
   // Derive groups from module list
   const groups = useMemo(() => groupModulesByGroup(modules), [modules]);

--- a/src/controller/frontend/src/basic/pages/Recording/RecordingLayout.jsx
+++ b/src/controller/frontend/src/basic/pages/Recording/RecordingLayout.jsx
@@ -23,6 +23,13 @@ function RecordingLayout() {
     const navigate = useNavigate();
     const [drawerOpen, setDrawerOpen] = useState(false);
 
+    // Set by SessionDetailPage's "Copy" button (via the outlet context
+    // below) to seed the New Session form with an existing session's
+    // target/mode/duration/schedule -- null the rest of the time, so the
+    // form's own persisted fields (last-used mode/duration/etc.) are what
+    // show up when opening the drawer normally via "+ New Session".
+    const [copyPrefill, setCopyPrefill] = useState(null);
+
     // useParams() here reflects the matched child route too (react-router
     // merges params up the whole matched tree), so this is populated with
     // the open session's name even though this component sits above the
@@ -52,6 +59,25 @@ function RecordingLayout() {
     // showing the whole fleet.
     const [target, setTarget] = usePersistedState("saviour_session_form_target", "all");
 
+    // "Copy" on the detail page: reopen the New Session drawer targeting
+    // the same modules/group and mode/duration/schedule as an existing
+    // session, so recreating a similar session doesn't mean reconfiguring
+    // everything from scratch. Deliberately doesn't touch the session-name
+    // fields (experiment/rat ID/etc, in SessionName) -- those already
+    // persist globally across sessions on their own, and every session
+    // name gets a fresh timestamp suffix regardless.
+    const openCopyDrawer = (session) => {
+        setTarget(session.target || "all");
+        setCopyPrefill({
+            mode: session.scheduled ? "scheduled" : session.duration_minutes ? "timed" : "immediate",
+            durationMinutes: session.duration_minutes,
+            scheduledStart: session.scheduled_start_time,
+            scheduledEnd: session.scheduled_end_time,
+            scheduledDays: session.scheduled_days,
+        });
+        setDrawerOpen(true);
+    };
+
     return (
         <div className="recording-page">
             <div className="recording-layout recording-layout--split">
@@ -64,7 +90,7 @@ function RecordingLayout() {
                     />
                 </div>
                 <div className="recording-layout__detail">
-                    <Outlet />
+                    <Outlet context={{ openCopyDrawer }} />
                 </div>
             </div>
 
@@ -74,14 +100,20 @@ function RecordingLayout() {
                 long-running habitat deployment), not something worth a
                 permanent slot competing with the rail for space at every
                 other visit. */}
-            <Drawer open={drawerOpen} onClose={() => setDrawerOpen(false)} title="New Session">
+            <Drawer
+                open={drawerOpen}
+                onClose={() => { setDrawerOpen(false); setCopyPrefill(null); }}
+                title="New Session"
+            >
                 <NewSessionForm
                     modules={moduleList}
                     sessionList={sessionList}
                     target={target}
                     setTarget={setTarget}
+                    prefill={copyPrefill}
                     onSessionCreated={(sessionName) => {
                         setDrawerOpen(false);
+                        setCopyPrefill(null);
                         navigate(`/recording/sessions/${encodeURIComponent(sessionName)}`);
                     }}
                 />

--- a/src/controller/frontend/src/basic/pages/Recording/SessionDetailPage/SessionDetailPage.jsx
+++ b/src/controller/frontend/src/basic/pages/Recording/SessionDetailPage/SessionDetailPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import { useParams, useNavigate, Link } from "react-router";
+import { useParams, useNavigate, useOutletContext, Link } from "react-router";
 import socket from "/src/socket";
 import useSessions from "/src/hooks/useSessions";
 import useModules from "/src/hooks/useModules";
@@ -100,6 +100,7 @@ export default function SessionDetailPage() {
   const navigate = useNavigate();
   const { sessions } = useSessions();
   const { moduleList: modules } = useModules();
+  const { openCopyDrawer } = useOutletContext();
 
   const [pendingDelete, setPendingDelete] = useState(false);
   const [addModuleTarget, setAddModuleTarget] = useState(false);
@@ -768,6 +769,13 @@ export default function SessionDetailPage() {
                 Retry Export
               </button>
             )}
+            <button
+              className="session-btn session-btn--copy"
+              onClick={() => openCopyDrawer(session)}
+              title="Create a new session with the same target and mode (immediate/timed/scheduled)"
+            >
+              Copy
+            </button>
             {(isStopped || (isPending && !editingPending)) && (
               pendingForceDelete ? (
                 <div className="delete-confirm delete-confirm--export-warning">

--- a/src/controller/frontend/src/basic/pages/Recording/SessionList/SessionList.css
+++ b/src/controller/frontend/src/basic/pages/Recording/SessionList/SessionList.css
@@ -404,6 +404,17 @@
   color: #333;
 }
 
+.session-btn--copy {
+  background: none;
+  color: #888;
+  border: 1px solid #bbb;
+}
+
+.session-btn--copy:hover {
+  color: #4a90d9;
+  border-color: #4a90d9;
+}
+
 .delete-confirm {
   display: flex;
   align-items: center;

--- a/src/controller/frontend/src/basic/pages/Recording/SessionList/SessionList.jsx
+++ b/src/controller/frontend/src/basic/pages/Recording/SessionList/SessionList.jsx
@@ -40,7 +40,12 @@ function SessionList({ sessionList, modules = [], onNewSession, selectedSessionN
     setClearAllWarning(null);
   };
 
-  const sessions = Object.values(sessionList);
+  // sessionList is keyed by session_name in backend insertion order (new
+  // sessions are only ever appended, per RecordingLayout's own auto-select
+  // effect) -- reverse so the rail reads newest-first, matching how an
+  // operator actually wants to scan it (most likely to click a session
+  // just created, not one from hours/days ago).
+  const sessions = Object.values(sessionList).slice().reverse();
   // "Ended" = stopped, or errored-and-not-scheduled-to-retry -- explicitly
   // not pending/active/scheduled. A PENDING session hasn't ended, it just
   // hasn't started yet; "Clear all ended" must never sweep those up.

--- a/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.css
+++ b/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.css
@@ -95,6 +95,15 @@
 .hrc-state--fault     { color: #c62828; }
 .hrc-state--ready     { color: var(--text-muted, #888); }
 
+.hrc-session-name {
+  font-size: 0.82rem;
+  color: var(--text-muted, #888);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
 .hrc-stat {
   font-size: 0.82rem;
   color: var(--text-muted, #888);

--- a/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.jsx
+++ b/src/controller/frontend/src/habitat/components/HabitatRecordingControl/HabitatRecordingControl.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import socket from "/src/socket";
 import useSessions from "/src/hooks/useSessions";
 import useModules from "/src/hooks/useModules";
+import { groupModulesByGroup, resolveTargetModules } from "../../../basic/pages/Recording/targetModules";
 import "./HabitatRecordingControl.css";
 
 function formatTime(t) {
@@ -76,13 +77,25 @@ export default function HabitatRecordingControl() {
     return () => socket.off("session_error", onError);
   }, []);
 
+  // A session's `target` is "all", a module `group` name, or a single
+  // module_id -- never a literal "camera"/"microphone" string, so matching
+  // against it directly (the previous approach here) missed the common
+  // case of a session targeting "all" or a custom per-enclosure group,
+  // leaving this banner stuck on "Idle" for an actually-active session.
+  // Resolve target -> actual modules the same way NewSessionForm/
+  // ReadinessSummary do, then check module *type* instead.
+  const moduleList = useMemo(() => Object.values(modules), [modules]);
+  const groups = useMemo(() => groupModulesByGroup(moduleList), [moduleList]);
+
   const cameraSession = useMemo(
-    () => sessionList.find(s => s.target?.includes("camera") && s.state !== "stopped"),
-    [sessionList]
+    () => sessionList.find(s => s.state !== "stopped" &&
+      resolveTargetModules(moduleList, s.target, groups).some(m => m.type?.includes("camera"))),
+    [sessionList, moduleList, groups]
   );
   const audioSession = useMemo(
-    () => sessionList.find(s => s.target === "microphone" && s.state !== "stopped"),
-    [sessionList]
+    () => sessionList.find(s => s.state !== "stopped" &&
+      resolveTargetModules(moduleList, s.target, groups).some(m => m.type === "microphone")),
+    [sessionList, moduleList, groups]
   );
 
   const isRecording = cameraSession?.state === "active";
@@ -90,7 +103,6 @@ export default function HabitatRecordingControl() {
     !Object.values(modules).some(m => m.type?.includes("camera") && m.status === "RECORDING");
   const hasFault    = cameraSession?.state === "error";
 
-  const moduleList      = useMemo(() => Object.values(modules), [modules]);
   const cameras         = moduleList.filter(m => m.type?.includes("camera"));
   const cameraOnline    = cameras.filter(m => m.online !== false).length;
   const cameraRecording = cameras.filter(m => m.status === "RECORDING").length;
@@ -141,6 +153,9 @@ export default function HabitatRecordingControl() {
         <span className={`hrc-state hrc-state--${isStarting ? "starting" : isRecording ? "recording" : hasFault ? "fault" : "ready"}`}>
           {stateLabel}
         </span>
+        {(isRecording || isStarting) && cameraSession?.session_name && (
+          <span className="hrc-session-name">{cameraSession.session_name}</span>
+        )}
         <span className="hrc-spacer" />
         <span className="hrc-stat">{cameraStr}</span>
         <span className="hrc-sep">·</span>


### PR DESCRIPTION
The habitat top-bar widget (HabitatRecordingControl) matched a session's target against literal "camera"/"microphone" strings, but target is actually "all", a module group name, or a module_id -- so a session created with the default "all" target never showed as recording. Now resolves target -> modules the same way NewSessionForm/ReadinessSummary do, and checks module type instead. Also surfaces the session name on the banner, which was previously never shown.

Other changes bundled from the same session:
- SessionDetailPage: new "Copy" button reopens the New Session drawer prefilled with an existing session's target/mode/duration/schedule.
- apa and acoustic_startle App.jsx were missing RecordingStatusWidget entirely -- mounted it above <Routes>, matching basic/habitat.
- SessionList: rail now shows newest sessions first instead of oldest.